### PR TITLE
Modifications to field properties and browsing dialog

### DIFF
--- a/4nxci-GUI/.gitignore
+++ b/4nxci-GUI/.gitignore
@@ -1,3 +1,0 @@
-.vs/*
-4nxci-GUI/bin/*
-4nxci-GUI/obj/*

--- a/4nxci-GUI/.gitignore
+++ b/4nxci-GUI/.gitignore
@@ -1,0 +1,3 @@
+.vs/*
+4nxci-GUI/bin/*
+4nxci-GUI/obj/*

--- a/4nxci-GUI/4nxci-GUI/MainWindow.xaml
+++ b/4nxci-GUI/4nxci-GUI/MainWindow.xaml
@@ -13,17 +13,17 @@
             <ColumnDefinition Width="351*"/>
         </Grid.ColumnDefinitions>
         <Label x:Name="lbl_outdir" Content="Output Directory:" HorizontalAlignment="Left" Margin="10,44,0,0" VerticalAlignment="Top"/>
-        <TextBox x:Name="txt_outdir" HorizontalAlignment="Left" Height="22" Margin="3.618,46,0,0" TextWrapping="NoWrap" VerticalAlignment="Top" Width="519" IsReadOnly="True" Grid.ColumnSpan="2" Grid.Column="1"/>
-        <Button x:Name="btn_browse_outdir" Content="Browse" HorizontalAlignment="Left" Margin="232.334,46,0,0" VerticalAlignment="Top" Width="102" Height="22" Click="btn_browse_outdir_Click" Grid.Column="2"/>
+        <TextBox x:Name="txt_outdir" HorizontalAlignment="Left" Height="22" Margin="3.618,46,0,0" TextWrapping="NoWrap" VerticalAlignment="Top" Width="519" Grid.ColumnSpan="2" Grid.Column="1" TabIndex="2"/>
+        <Button x:Name="btn_browse_outdir" Content="Browse" HorizontalAlignment="Left" Margin="232.334,46,0,0" VerticalAlignment="Top" Width="102" Height="22" Click="btn_browse_outdir_Click" Grid.Column="2" TabIndex="3"/>
         <TextBox x:Name="txt_log" HorizontalAlignment="Left" Height="184" Margin="10,138,0,0" TextWrapping="NoWrap" VerticalAlignment="Top" Width="733" Grid.ColumnSpan="3" IsReadOnly="True" ScrollViewer.VerticalScrollBarVisibility="Auto"/>
         <Label x:Name="lbl_keyset" Content="Keyset File:" HorizontalAlignment="Left" Margin="44,78,0,0" VerticalAlignment="Top" RenderTransformOrigin="0,0.561"/>
-        <TextBox x:Name="txt_keyset" HorizontalAlignment="Left" Height="22" Margin="3.618,80,0,0" TextWrapping="NoWrap" VerticalAlignment="Top" Width="519" IsReadOnly="True" Grid.ColumnSpan="2" Grid.Column="1"/>
-        <Button x:Name="btn_browse_keyset" Content="Browse" HorizontalAlignment="Left" Margin="232.334,80,0,0" VerticalAlignment="Top" Width="102" Height="22" Click="btn_browse_keyset_Click" Grid.Column="2"/>
+        <TextBox x:Name="txt_keyset" HorizontalAlignment="Left" Height="22" Margin="3.618,80,0,0" TextWrapping="NoWrap" VerticalAlignment="Top" Width="519" Grid.ColumnSpan="2" Grid.Column="1" TabIndex="4"/>
+        <Button x:Name="btn_browse_keyset" Content="Browse" HorizontalAlignment="Left" Margin="232.334,80,0,0" VerticalAlignment="Top" Width="102" Height="22" Click="btn_browse_keyset_Click" Grid.Column="2" TabIndex="5"/>
         <Label x:Name="lbl_xci" Content="XCI:" HorizontalAlignment="Left" Margin="82,11,0,0" VerticalAlignment="Top"/>
-        <TextBox x:Name="txt_xci" HorizontalAlignment="Left" Height="22" Margin="3.618,13,0,0" TextWrapping="NoWrap" VerticalAlignment="Top" Width="519" IsReadOnly="True" Grid.ColumnSpan="2" Grid.Column="1"/>
-        <Button x:Name="btn_xci" Content="Browse" HorizontalAlignment="Left" Margin="232.334,13,0,0" VerticalAlignment="Top" Width="102" Height="22" Click="btn_xci_Click" Grid.Column="2"/>
-        <Button x:Name="btn_convert" Content="Convert" HorizontalAlignment="Left" Margin="232.334,111,0,0" VerticalAlignment="Top" Width="102" Height="22" Click="btn_convert_Click" Grid.Column="2"/>
-        <CheckBox x:Name="chk_rename" Content="Use Titlename" HorizontalAlignment="Left" Margin="3.618,116,0,0" VerticalAlignment="Top" Width="97" Grid.Column="1"/>
-        <CheckBox x:Name="chk_keepncaid" Content="Keep Ncaid" HorizontalAlignment="Left" Margin="116.618,116,0,0" VerticalAlignment="Top" Width="87" Grid.Column="1"/>
+        <TextBox x:Name="txt_xci" HorizontalAlignment="Left" Height="22" Margin="3.618,13,0,0" TextWrapping="NoWrap" VerticalAlignment="Top" Width="519" Grid.ColumnSpan="2" Grid.Column="1" TabIndex="0"/>
+        <Button x:Name="btn_xci" Content="Browse" HorizontalAlignment="Left" Margin="232.334,13,0,0" VerticalAlignment="Top" Width="102" Height="22" Click="btn_xci_Click" Grid.Column="2" TabIndex="1"/>
+        <Button x:Name="btn_convert" Content="Convert" HorizontalAlignment="Left" Margin="232.334,111,0,0" VerticalAlignment="Top" Width="102" Height="22" Click="btn_convert_Click" Grid.Column="2" TabIndex="8"/>
+        <CheckBox x:Name="chk_rename" Content="Use Titlename" HorizontalAlignment="Left" Margin="3.618,116,0,0" VerticalAlignment="Top" Width="97" Grid.Column="1" TabIndex="6"/>
+        <CheckBox x:Name="chk_keepncaid" Content="Keep Ncaid" HorizontalAlignment="Left" Margin="116.618,116,0,0" VerticalAlignment="Top" Width="87" Grid.Column="1" TabIndex="7"/>
     </Grid>
 </Window>

--- a/4nxci-GUI/4nxci-GUI/MainWindow.xaml.cs
+++ b/4nxci-GUI/4nxci-GUI/MainWindow.xaml.cs
@@ -15,6 +15,7 @@ using System.IO;
 using System.ComponentModel;
 using System.Collections;
 using System.Globalization;
+using Path = System.IO.Path;
 
 namespace hacPack_GUI
 {
@@ -111,17 +112,43 @@ namespace hacPack_GUI
                 txtbox.Text = browse_dialog.SelectedPath;
         }
 
+        private void browse_folder(ref System.Windows.Controls.TextBox txtbox, string selectedPath)
+        {
+            FolderBrowserDialog browse_dialog = new FolderBrowserDialog();
+            if (selectedPath != string.Empty)
+            {
+                browse_dialog.RootFolder = Environment.SpecialFolder.Desktop;
+                browse_dialog.SelectedPath = selectedPath;
+            }
+            DialogResult dialog_result = browse_dialog.ShowDialog();
+            if (dialog_result == System.Windows.Forms.DialogResult.OK)
+                txtbox.Text = browse_dialog.SelectedPath;
+        }
+
         private void browse_file(ref System.Windows.Controls.TextBox txtbox)
         {
             OpenFileDialog nca_browse_dialog = new OpenFileDialog();
             DialogResult dialog_result = nca_browse_dialog.ShowDialog();
             if (dialog_result == System.Windows.Forms.DialogResult.OK)
+            {
                 txtbox.Text = nca_browse_dialog.FileName;
+                if (txtbox.Name == "txt_xci" && txt_outdir.Text == string.Empty)
+                {
+                    txt_outdir.Text = Path.GetDirectoryName(txt_xci.Text);
+                }
+            }
         }
 
         private void btn_browse_outdir_Click(object sender, RoutedEventArgs e)
         {
-            browse_folder(ref txt_outdir);
+            if (txt_outdir.Text == string.Empty)
+            {
+                browse_folder(ref txt_outdir);
+            }
+            else
+            {                
+                browse_folder(ref txt_outdir, txt_outdir.Text);
+            }            
         }
 
         private void btn_browse_keyset_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Some things I thought could be an improvement overall:
1. Removed read only from xci, output and keys fields.
2. Used tabIndex property to allow proper tab browsing in order.
3. Set output folder equal to folder where XCI is located. If an output folder was selected previously, doesn't change anything.
4. Browse dialog for output folder now automatically selects the folder in text field, if set.