### PR TITLE
Initializes keyset field with keys.dat on executable folder, if exists

### DIFF
--- a/4nxci-GUI/4nxci-GUI/MainWindow.xaml.cs
+++ b/4nxci-GUI/4nxci-GUI/MainWindow.xaml.cs
@@ -35,6 +35,16 @@ namespace hacPack_GUI
             {
                 System.Windows.Application.Current.Shutdown();
             }
+
+            initializeKeyset();
+        }
+
+        private void initializeKeyset()
+        {
+            if (File.Exists(".\\keys.dat"))
+            {
+                txt_keyset.Text = Path.GetFullPath(".\\keys.dat");
+            }
         }
 
         private bool is_4nxci_exists()


### PR DESCRIPTION
Thought process is:

CLI doesn't ask for a key if keys.dat present, but GUI does ("Keyset path is empty"). So I think it makes sense to initialize the keyset field with keys.dat location, if found, so user doesn't have to do an extra unnecessary step.