### PR TITLE
Modifications to convert button

### DIFF
--- a/4nxci-GUI/4nxci-GUI/MainWindow.xaml.cs
+++ b/4nxci-GUI/4nxci-GUI/MainWindow.xaml.cs
@@ -16,6 +16,7 @@ using System.ComponentModel;
 using System.Collections;
 using System.Globalization;
 using Path = System.IO.Path;
+using System.Threading;
 
 namespace hacPack_GUI
 {
@@ -87,6 +88,7 @@ namespace hacPack_GUI
         {
             if (is_4nxci_exists() == true && check_general_options() == true)
             {
+                btn_convert.IsEnabled = false;
                 string nxci_args;
                 nxci_args = "\"" + txt_xci.Text + "\" -k \"" + txt_keyset.Text + "\" -o \"" + txt_outdir.Text + "\" " + args;
                 Process nxci = new Process();
@@ -98,10 +100,21 @@ namespace hacPack_GUI
                 nxci.OutputDataReceived += OnOutputDataReceived;
                 nxci.ErrorDataReceived += OnOutputDataReceived;
                 nxci.StartInfo.CreateNoWindow = true;
+                nxci.EnableRaisingEvents = true;
+                nxci.Exited += new EventHandler(has_4ncxi_exited);
                 nxci.Start();
+                txt_log.Text = "4nxci execution started. Please wait...\n\n";
                 nxci.BeginOutputReadLine();
-                nxci.BeginErrorReadLine();
+                nxci.BeginErrorReadLine();                            
             }
+        }
+
+        private void has_4ncxi_exited(object sender, System.EventArgs e)
+        {
+            this.Dispatcher.Invoke(() =>
+            {
+                btn_convert.IsEnabled = true;
+            });
         }
 
         private void browse_folder(ref System.Windows.Controls.TextBox txtbox)

--- a/4nxci-GUI/4nxci-GUI/MainWindow.xaml.cs
+++ b/4nxci-GUI/4nxci-GUI/MainWindow.xaml.cs
@@ -1,22 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Forms;
 using System.Diagnostics;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 using System.IO;
-using System.ComponentModel;
-using System.Collections;
-using System.Globalization;
 using Path = System.IO.Path;
-using System.Threading;
 
 namespace hacPack_GUI
 {
@@ -105,7 +92,7 @@ namespace hacPack_GUI
                 nxci.Start();
                 txt_log.Text = "4nxci execution started. Please wait...\n\n";
                 nxci.BeginOutputReadLine();
-                nxci.BeginErrorReadLine();                            
+                nxci.BeginErrorReadLine();
             }
         }
 


### PR DESCRIPTION
When convert button is pressed, user doesn't get any clear feedback that the process is executing:
1. User can press convert button many times (which results in errors due to overwriting files -e.g NCAs- between several 4ncxi.exe processes running at the same time.
2. Log is only shown at the end of the process so user only gets feedback 30 seconds+ later.

This fix:
1. As soon as convert button is pressed and all conditions are met to run 4ncxi.exe, button is disabled.
2. Log shows message about process start.
3. When process finishes (4ncxi.exe), button is enabled again.