### PR TITLE
Modified CLI to allow proper sync of output (std and err) on GUI

### DIFF
--- a/4nxci-GUI/4nxci-GUI/MainWindow.xaml
+++ b/4nxci-GUI/4nxci-GUI/MainWindow.xaml
@@ -15,7 +15,7 @@
         <Label x:Name="lbl_outdir" Content="Output Directory:" HorizontalAlignment="Left" Margin="10,44,0,0" VerticalAlignment="Top"/>
         <TextBox x:Name="txt_outdir" HorizontalAlignment="Left" Height="22" Margin="3.618,46,0,0" TextWrapping="NoWrap" VerticalAlignment="Top" Width="519" Grid.ColumnSpan="2" Grid.Column="1" TabIndex="2"/>
         <Button x:Name="btn_browse_outdir" Content="Browse" HorizontalAlignment="Left" Margin="232.334,46,0,0" VerticalAlignment="Top" Width="102" Height="22" Click="btn_browse_outdir_Click" Grid.Column="2" TabIndex="3"/>
-        <TextBox x:Name="txt_log" HorizontalAlignment="Left" Height="184" Margin="10,138,0,0" TextWrapping="NoWrap" VerticalAlignment="Top" Width="733" Grid.ColumnSpan="3" IsReadOnly="True" ScrollViewer.VerticalScrollBarVisibility="Auto"/>
+        <TextBox x:Name="txt_log" HorizontalAlignment="Left" Height="184" Margin="10,138,0,0" TextWrapping="NoWrap" VerticalAlignment="Top" Width="733" Grid.ColumnSpan="3" IsReadOnly="True" ScrollViewer.VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto"/>
         <Label x:Name="lbl_keyset" Content="Keyset File:" HorizontalAlignment="Left" Margin="44,78,0,0" VerticalAlignment="Top" RenderTransformOrigin="0,0.561"/>
         <TextBox x:Name="txt_keyset" HorizontalAlignment="Left" Height="22" Margin="3.618,80,0,0" TextWrapping="NoWrap" VerticalAlignment="Top" Width="519" Grid.ColumnSpan="2" Grid.Column="1" TabIndex="4"/>
         <Button x:Name="btn_browse_keyset" Content="Browse" HorizontalAlignment="Left" Margin="232.334,80,0,0" VerticalAlignment="Top" Width="102" Height="22" Click="btn_browse_keyset_Click" Grid.Column="2" TabIndex="5"/>

--- a/main.c
+++ b/main.c
@@ -44,6 +44,9 @@ int main(int argc, char **argv)
 {
     nxci_ctx_t tool_ctx;
     char input_name[0x200];
+	
+	setbuf(stdout, NULL);
+	setbuf(stderr, NULL);
 
     printf("4NXCI %s by The-4n\n", NXCI_VERSION);
 

--- a/main.c
+++ b/main.c
@@ -45,8 +45,8 @@ int main(int argc, char **argv)
     nxci_ctx_t tool_ctx;
     char input_name[0x200];
 	
-	setbuf(stdout, NULL);
-	setbuf(stderr, NULL);
+    setbuf(stdout, NULL);
+    setbuf(stderr, NULL);
 
     printf("4NXCI %s by The-4n\n", NXCI_VERSION);
 


### PR DESCRIPTION
Log field on GUI was only appending output from the CLI at the end of the process, due to buffering on printf, sprintf etc.
I disabled buffering (not critical on this application as logs are always small) and now the GUI properly displays output:
1. In real-time
2. In proper order (before, errors will always append at the end, which looks weird)
So basically, log field now displays exactly as if executed the CLI on console.

Also I added a horizontal scrollbar (automatic, if required) for better viewing, as most times the content will span beyond horizontal limits.